### PR TITLE
Fix/post types filter

### DIFF
--- a/includes/class-revision-strike.php
+++ b/includes/class-revision-strike.php
@@ -91,14 +91,13 @@ class RevisionStrike {
 	public function count_eligible_revisions( $days, $post_type ) {
 		global $wpdb;
 
-		$post_type = array_map( 'trim', explode( ',', $post_type ) );
+		$post_type_in_string = $this->get_slug_in_string( $post_type );
 		$count     = $wpdb->get_var( $wpdb->prepare(
 			"
 			SELECT COUNT(r.ID) FROM $wpdb->posts r
 			LEFT JOIN $wpdb->posts p ON r.post_parent = p.ID
-			WHERE r.post_type = 'revision' AND p.post_type IN ('%s') AND p.post_date < %s
+			WHERE r.post_type = 'revision' AND p.post_type IN ($post_type_in_string) AND p.post_date < %s
 			",
-			implode( "', '", $post_type ),
 			date( 'Y-m-d', time() - ( absint( $days ) * DAY_IN_SECONDS ) )
 		) );
 
@@ -174,6 +173,38 @@ class RevisionStrike {
 	}
 
 	/**
+	 * Converts a comma-delimited list of slugs into a string usable
+	 * as with an SQL IN statement.
+	 *
+	 * @param  string $post_type Comma-delimited list of slugs (post,page).
+	 * @return string List of slugs for IN statement ('post','page').
+	 */
+	protected function get_slug_in_string( $slugs ) {
+
+		/*
+		This mimics the functionality in core for building IN strings.
+		From post.php:
+		$post_types = esc_sql( $post_types );
+		$post_type_in_string = "'" . implode( "','", $post_types ) . "'";
+		$sql = "
+			SELECT ID, post_name, post_parent, post_type
+			FROM $wpdb->posts
+			WHERE post_name IN ($in_string)
+			AND post_type IN ($post_type_in_string)
+		";
+		 */
+
+		// Split the list into an array.
+		$slugs = explode( ',', $slugs );
+
+		// Run esc_sql on the array of slugs
+		$slugs = esc_sql( $slugs );
+
+		// Return a string usable in an IN statement
+		return "'" . implode( "','", $slugs ) . "'";
+	}
+
+	/**
 	 * Find revisions eligible to be removed from the database.
 	 *
 	 * @global $wpdb
@@ -193,19 +224,19 @@ class RevisionStrike {
 			return array();
 		}
 
-		$post_type    = array_map( 'trim', explode( ',', $post_type ) );
+		$post_type_in_string = $this->get_slug_in_string( $post_type );
 		$revision_ids = $wpdb->get_col( $wpdb->prepare(
 			"
 			SELECT r.ID FROM $wpdb->posts r
 			LEFT JOIN $wpdb->posts p ON r.post_parent = p.ID
-			WHERE r.post_type = 'revision' AND p.post_type IN ('%s') AND p.post_date < %s
+			WHERE r.post_type = 'revision' AND p.post_type IN ($post_type_in_string) AND p.post_date < %s
 			ORDER BY p.post_date ASC
 			LIMIT %d
 			",
-			implode( "', '", $post_type ),
 			date( 'Y-m-d', time() - ( absint( $days ) * DAY_IN_SECONDS ) ),
 			absint( $limit )
 		) );
+
 
 		/**
 		 * Filter the list of eligible revision IDs.

--- a/includes/class-revision-strike.php
+++ b/includes/class-revision-strike.php
@@ -150,15 +150,12 @@ class RevisionStrike {
 		);
 		$args         = wp_parse_args( $args, $default_args );
 
-		if ( null === $args['post_type'] ) {
-
-			/**
-			 * Set the default post type(s) for which revisions should be struck.
-			 *
-			 * @param string $post_type A comma-separated list of post types.
-			 */
-			$args['post_type'] = apply_filters( 'revisionstrike_post_types', 'post' );
-		}
+		/**
+		 * Set the post type(s) for which revisions should be struck.
+		 *
+		 * @param string $post_type A comma-separated list of post types.
+		 */
+		$args['post_type'] = apply_filters( 'revisionstrike_post_types', $args['post_type'] );
 
 		// Calculate the number of batches to run.
 		$limit       = self::BATCH_SIZE >= $args['limit'] ? $args['limit'] : self::BATCH_SIZE;

--- a/tests/PHPUnit/RevisionStrikeTest.php
+++ b/tests/PHPUnit/RevisionStrikeTest.php
@@ -69,7 +69,7 @@ class RevisionStrikeTest extends TestCase {
 		$wpdb = Mockery::mock( '\WPDB' );
 		$wpdb->shouldReceive( 'prepare' )
 			->once()
-			->with( Mockery::any(), 'post', Mockery::any() )
+			->with( Mockery::any(), Mockery::any() )
 			->andReturnUsing( function ( $query ) {
 				if ( 0 !== strpos( trim( $query ), 'SELECT COUNT(r.ID) FROM' ) ) {
 					$this->fail( 'Results are not being limited to a count' );
@@ -83,6 +83,7 @@ class RevisionStrikeTest extends TestCase {
 		$wpdb->posts = 'wp_posts';
 
 		M::wpPassthruFunction( 'absint' );
+		M::wpPassthruFunction( 'esc_sql' );
 
 		$this->assertEquals( 12, $instance->count_eligible_revisions( 30, 'post' ) );
 		$wpdb = null;
@@ -106,6 +107,30 @@ class RevisionStrikeTest extends TestCase {
 		$property->setValue( $instance, $value );
 
 		$this->assertEquals( $value, $instance->get_stats() );
+	}
+
+	public function test_single_get_slug_in_string() {
+
+		$instance = Mockery::mock( 'RevisionStrike' )
+			->shouldAllowMockingProtectedMethods()
+			->makePartial();
+
+		M::wpPassthruFunction( 'esc_sql' );
+
+		$this->assertEquals( "'post'", $instance->get_slug_in_string( 'post' ) );
+
+	}
+
+	public function test_multiple_get_slug_in_string() {
+
+		$instance = Mockery::mock( 'RevisionStrike' )
+			->shouldAllowMockingProtectedMethods()
+			->makePartial();
+
+		M::wpPassthruFunction( 'esc_sql' );
+
+		$this->assertEquals( "'post','page'", $instance->get_slug_in_string( 'post,page' ) );
+
 	}
 
 	public function test_strike() {
@@ -201,6 +226,7 @@ class RevisionStrikeTest extends TestCase {
 		) );
 
 		M::wpPassthruFunction( 'absint' );
+		M::wpPassthruFunction( 'esc_sql' );
 
 		// change the post type with the filter
 		M::onFilter( 'revisionstrike_post_types' )
@@ -273,7 +299,7 @@ class RevisionStrikeTest extends TestCase {
 		$wpdb = Mockery::mock( '\WPDB' );
 		$wpdb->shouldReceive( 'prepare' )
 			->once()
-			->with( Mockery::any(), 'post', Mockery::any(), 25 )
+			->with( Mockery::any(), Mockery::any(), 25 )
 			->andReturnUsing( function ( $query ) {
 				if ( false === strpos( $query, 'ORDER BY p.post_date ASC' ) ) {
 					$this->fail( 'Revisions are not being ordered from oldest to newest' );
@@ -287,6 +313,7 @@ class RevisionStrikeTest extends TestCase {
 		$wpdb->posts = 'wp_posts';
 
 		M::wpPassthruFunction( 'absint' );
+		M::wpPassthruFunction( 'esc_sql' );
 
 		$result = $method->invoke( $instance, 90, 25, 'post' );
 		$wpdb   = null;
@@ -307,7 +334,7 @@ class RevisionStrikeTest extends TestCase {
 		$wpdb = Mockery::mock( '\WPDB' );
 		$wpdb->shouldReceive( 'prepare' )
 			->once()
-			->with( Mockery::any(), "post', 'page", Mockery::any(), 50 )
+			->with( Mockery::any(), Mockery::any(), 50 )
 			->andReturn( 'SQL STATEMENT' );
 		$wpdb->shouldReceive( 'get_col' )
 			->once()
@@ -316,6 +343,7 @@ class RevisionStrikeTest extends TestCase {
 		$wpdb->posts = 'wp_posts';
 
 		M::wpPassthruFunction( 'absint' );
+		M::wpPassthruFunction( 'esc_sql' );
 
 		$result = $method->invoke( $instance, 30, 50, 'post,page' );
 		$wpdb   = null;
@@ -342,6 +370,7 @@ class RevisionStrikeTest extends TestCase {
 		$wpdb->posts = 'wp_posts';
 
 		M::wpPassthruFunction( 'absint' );
+		M::wpPassthruFunction( 'esc_sql' );
 
 		M::onFilter( 'revisionstrike_get_revision_ids' )
 			->with( array( 1, 2, 3 ), 90, 25, array( 'post' ) )


### PR DESCRIPTION
- Fixes the bug where the `revisionstrike_post_types` filter was never being called
- Fixes SQL formatting issues with the `post_type IN` clause in the query
- Adds new unit tests get_slug_in_string(), updated existing unit tests
