### PR TITLE
Update method access to allow delete hook to work

### DIFF
--- a/includes/class-revision-strike-cli.php
+++ b/includes/class-revision-strike-cli.php
@@ -135,7 +135,7 @@ class RevisionStrikeCLI extends WP_CLI {
 	 * @param int          $revision_id Post revision ID.
 	 * @param object|array $revision    Post revision object or array.
 	 */
-	protected function log_deleted_revision( $revision_id, $revision ) {
+	public function log_deleted_revision( $revision_id, $revision ) {
 		WP_CLI::log( sprintf(
 			esc_html__( 'Revision ID %d has been deleted.', 'revision-strike' ),
 			$revision_id


### PR DESCRIPTION
Allows hook at https://github.com/stevegrunwell/revision-strike/blob/develop/includes/class-revision-strike-cli.php#L59 to run.

Avoids:
Warning: call_user_func_array() expects parameter 1 to be a valid callback, cannot access protected method RevisionStrikeCLI::log_deleted_revision() in ...