### PR TITLE
Avoid division by zero

### DIFF
--- a/includes/class-revision-strike.php
+++ b/includes/class-revision-strike.php
@@ -160,7 +160,7 @@ class RevisionStrike {
 
 		// Calculate the number of batches to run.
 		$limit       = self::BATCH_SIZE >= $args['limit'] ? $args['limit'] : self::BATCH_SIZE;
-		$batch_count = ceil( $args['limit'] / $limit );
+		$batch_count = $limit > 0 ? ceil( $args['limit'] / $limit ) : 0;
 
 		for ( $i = 0; $i < $batch_count; $i++ ) {
 			$revision_ids = $this->get_revision_ids( $args['days'], $limit, $args['post_type'] );


### PR DESCRIPTION
Avoids this scenario:
PHP Warning:  Division by zero in /wp-content/plugins/revision-strike/includes/class-revision-strike.php on line 163

When:
Success: No errors occurred, but no post revisions were removed.